### PR TITLE
fix(ci): use GH_TOKEN for semantic-release to bypass repo rules

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
       with:
         fetch-depth: 0
         token: ${{ secrets.SEMANTIC_RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
-        persist-credentials: false
+        persist-credentials: true
     
     - name: Setup Node.js
       uses: actions/setup-node@v6
@@ -194,10 +194,13 @@ jobs:
       run: |
         REPO_URL="https://x-access-token:${{ secrets.SEMANTIC_RELEASE_TOKEN || secrets.GITHUB_TOKEN }}@github.com/andrewgibson-cic/slapenir"
         git remote set-url origin "${REPO_URL}"
+        git config user.name "semantic-release-bot"
+        git config user.email "semantic-release-bot@users.noreply.github.com"
     
     - name: Run semantic-release
       env:
-        GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
       run: npx semantic-release
     
     - name: Get version


### PR DESCRIPTION
## Summary

- Fix semantic-release failing with "Changes must be made through a pull request" error
- Use `GH_TOKEN` env var (checked first by semantic-release v23) for the admin PAT instead of `GITHUB_TOKEN`
- Set `persist-credentials: true` on checkout to retain PAT in git config
- Add explicit git user config for proper commit identity

## Root Cause

The repository has a ruleset (ID: 14484762) enforcing that all changes to `main` must go through a pull request. The admin PAT (`SEMANTIC_RELEASE_TOKEN`) has bypass permissions via the `RepositoryRole` admin bypass actor, but `@semantic-release/git` was constructing its push URL from `GITHUB_TOKEN` which conflicts with GitHub Actions' auto-injected Actions token (which does NOT bypass rulesets).

## Changes

| File | Change |
|------|--------|
| `.github/workflows/release.yml:96` | `persist-credentials: false` → `true` |
| `.github/workflows/release.yml:197-198` | Add `git config user.name/email` |
| `.github/workflows/release.yml:202-203` | `GITHUB_TOKEN` → Actions token, add `GH_TOKEN` → PAT |

## Testing

This can only be fully verified by triggering the release workflow. The changes are minimal and only affect the semantic-release job's authentication flow.

Fixes: https://github.com/andrewgibson-cic/slapenir/actions/runs/23785540738/job/69308108359